### PR TITLE
Replaced imports to the new fork

### DIFF
--- a/device/conn_linux.go
+++ b/device/conn_linux.go
@@ -24,7 +24,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"git.zx2c4.com/wireguard-go/rwcancel"
+	"github.com/mysteriumnetwork/wireguard-go/rwcancel"
 	"golang.org/x/sys/unix"
 )
 

--- a/device/cookie.go
+++ b/device/cookie.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"git.zx2c4.com/wireguard-go/xchacha20poly1305"
+	"github.com/mysteriumnetwork/wireguard-go/xchacha20poly1305"
 	"golang.org/x/crypto/blake2s"
 	"golang.org/x/crypto/chacha20poly1305"
 )

--- a/device/device.go
+++ b/device/device.go
@@ -11,8 +11,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"git.zx2c4.com/wireguard-go/ratelimiter"
-	"git.zx2c4.com/wireguard-go/tun"
+	"github.com/mysteriumnetwork/wireguard-go/ratelimiter"
+	"github.com/mysteriumnetwork/wireguard-go/tun"
 )
 
 const (

--- a/device/exported_device.go
+++ b/device/exported_device.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"time"
 
-	"git.zx2c4.com/wireguard-go/tun"
+	"github.com/mysteriumnetwork/wireguard-go/tun"
 )
 
 // The purpose of this DeviceApi is to wrap actual device and export variuos method which don't exist or

--- a/device/helper_test.go
+++ b/device/helper_test.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"testing"
 
-	"git.zx2c4.com/wireguard-go/tun"
+	"github.com/mysteriumnetwork/wireguard-go/tun"
 )
 
 /* Helpers for writing unit tests

--- a/device/keypair.go
+++ b/device/keypair.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"git.zx2c4.com/wireguard-go/replay"
+	"github.com/mysteriumnetwork/wireguard-go/replay"
 )
 
 /* Due to limitations in Go and /x/crypto there is currently

--- a/device/noise-protocol.go
+++ b/device/noise-protocol.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"git.zx2c4.com/wireguard-go/tai64n"
+	"github.com/mysteriumnetwork/wireguard-go/tai64n"
 	"golang.org/x/crypto/blake2s"
 	"golang.org/x/crypto/chacha20poly1305"
 	"golang.org/x/crypto/poly1305"

--- a/device/tun.go
+++ b/device/tun.go
@@ -8,7 +8,7 @@ package device
 import (
 	"sync/atomic"
 
-	"git.zx2c4.com/wireguard-go/tun"
+	"github.com/mysteriumnetwork/wireguard-go/tun"
 )
 
 const DefaultMTU = 1420

--- a/device/uapi_linux.go
+++ b/device/uapi_linux.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"path"
 
-	"git.zx2c4.com/wireguard-go/rwcancel"
+	"github.com/mysteriumnetwork/wireguard-go/rwcancel"
 	"golang.org/x/sys/unix"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module git.zx2c4.com/wireguard-go
+module github.com/mysteriumnetwork/wireguard-go
 
 require (
 	golang.org/x/crypto v0.0.0-20181001203147-e3636079e1a4

--- a/main.go
+++ b/main.go
@@ -13,8 +13,8 @@ import (
 	"strconv"
 	"syscall"
 
-	"git.zx2c4.com/wireguard-go/device"
-	"git.zx2c4.com/wireguard-go/tun"
+	"github.com/mysteriumnetwork/wireguard-go/device"
+	"github.com/mysteriumnetwork/wireguard-go/tun"
 )
 
 const (

--- a/tun/tun_darwin.go
+++ b/tun/tun_darwin.go
@@ -8,14 +8,15 @@ package tun
 import (
 	"errors"
 	"fmt"
-	"git.zx2c4.com/wireguard-go/rwcancel"
-	"golang.org/x/net/ipv6"
-	"golang.org/x/sys/unix"
 	"io/ioutil"
 	"net"
 	"os"
 	"syscall"
 	"unsafe"
+
+	"github.com/mysteriumnetwork/wireguard-go/rwcancel"
+	"golang.org/x/net/ipv6"
+	"golang.org/x/sys/unix"
 )
 
 const utunControlName = "com.apple.net.utun_control"

--- a/tun/tun_freebsd.go
+++ b/tun/tun_freebsd.go
@@ -9,13 +9,14 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"git.zx2c4.com/wireguard-go/rwcancel"
-	"golang.org/x/net/ipv6"
-	"golang.org/x/sys/unix"
 	"net"
 	"os"
 	"syscall"
 	"unsafe"
+
+	"github.com/mysteriumnetwork/wireguard-go/rwcancel"
+	"golang.org/x/net/ipv6"
+	"golang.org/x/sys/unix"
 )
 
 // _TUNSIFHEAD, value derived from sys/net/{if_tun,ioccom}.h

--- a/tun/tun_linux.go
+++ b/tun/tun_linux.go
@@ -12,15 +12,16 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"git.zx2c4.com/wireguard-go/rwcancel"
-	"golang.org/x/net/ipv6"
-	"golang.org/x/sys/unix"
 	"net"
 	"os"
 	"strconv"
 	"sync"
 	"time"
 	"unsafe"
+
+	"github.com/mysteriumnetwork/wireguard-go/rwcancel"
+	"golang.org/x/net/ipv6"
+	"golang.org/x/sys/unix"
 )
 
 const (

--- a/tun/tun_openbsd.go
+++ b/tun/tun_openbsd.go
@@ -8,14 +8,15 @@ package tun
 import (
 	"errors"
 	"fmt"
-	"git.zx2c4.com/wireguard-go/rwcancel"
-	"golang.org/x/net/ipv6"
-	"golang.org/x/sys/unix"
 	"io/ioutil"
 	"net"
 	"os"
 	"syscall"
 	"unsafe"
+
+	"github.com/mysteriumnetwork/wireguard-go/rwcancel"
+	"golang.org/x/net/ipv6"
+	"golang.org/x/sys/unix"
 )
 
 // Structure for iface mtu get/set ioctls

--- a/tun/tunhackforandroid_linux.go
+++ b/tun/tunhackforandroid_linux.go
@@ -3,7 +3,7 @@ package tun
 import (
 	"os"
 
-	"git.zx2c4.com/wireguard-go/rwcancel"
+	"github.com/mysteriumnetwork/wireguard-go/rwcancel"
 )
 
 func AndroidTunDevice(fd int) (TUNDevice, error) {


### PR DESCRIPTION
https://github.com/mysteriumnetwork/node/issues/390#issuecomment-450813908
> Looks like we are using original name "git.zx2c4.com/wireguard-go/", but substituting it with our fork. IMHO this is bogus, since we depend on package manager. Those who will fetch our sources and try to use other packaging might go into trouble.
> I think we should use our package naming (forked) since it is very confusing and in general our source does not comply contract implemented by "git.zx2c4.com/wireguard-go/".